### PR TITLE
Implement bulk algorithm for p2079

### DIFF
--- a/include/exec/system_scheduler.hpp
+++ b/include/exec/system_scheduler.hpp
@@ -195,7 +195,7 @@ struct __exec_system_bulk_pool_receiver {
 struct __exec_system_bulk_operation_state_impl : public __exec_system_operation_state_interface {
   __exec_system_bulk_operation_state_impl(
     __exec_pool_sender_t&& pool_sender,
-    __exec_system_recever&& recv) :
+    __exec_system_receiver&& recv) :
     recv_{std::move(recv)},
     // TODO: Clearly this is going to be more sophisticated to launch multiple elements
     // TODO: Call bulk_function_ across pool
@@ -213,7 +213,7 @@ struct __exec_system_bulk_operation_state_impl : public __exec_system_operation_
     stdexec::start(pool_operation_state_);
   }
 
-  __exec_system_recever recv_;
+  __exec_system_receiver recv_;
   __exec_system_bulk_function* bulk_function_;
   decltype(stdexec::connect(
       std::move(std::declval<__exec_pool_sender_t>()), std::move(std::declval<__exec_system_bulk_pool_receiver>())))
@@ -221,12 +221,12 @@ struct __exec_system_bulk_operation_state_impl : public __exec_system_operation_
 };
 
 inline void tag_invoke(stdexec::set_value_t, __exec_system_bulk_pool_receiver&& recv) noexcept {
-  __exec_system_recever &system_recv = recv.os_->recv_;
+  __exec_system_receiver &system_recv = recv.os_->recv_;
   system_recv.set_value((system_recv.cpp_recv_));
 }
 
 inline void tag_invoke(stdexec::set_stopped_t, __exec_system_bulk_pool_receiver&& recv) noexcept {
-  __exec_system_recever &system_recv = recv.os_->recv_;
+  __exec_system_receiver &system_recv = recv.os_->recv_;
   recv.os_->recv_.set_stopped(&(system_recv.cpp_recv_));
 }
 
@@ -239,7 +239,7 @@ struct __exec_system_bulk_sender_impl : public __exec_system_sender_interface {
 
   }
 
-  __exec_system_operation_state_interface* connect(__exec_system_recever recv) noexcept override {
+  __exec_system_operation_state_interface* connect(__exec_system_receiver recv) noexcept override {
     return
       new __exec_system_bulk_operation_state_impl(std::move(pool_sender_), std::move(recv));
   }
@@ -470,7 +470,7 @@ namespace exec {
         std::move(snd),
         std::move(rec),
         [](auto& op){
-          __exec_system_recever receiver_impl{
+          __exec_system_receiver receiver_impl{
             &op.recv_,
             [](void* cpp_recv){
               stdexec::set_value(std::move(*static_cast<R*>(cpp_recv)));

--- a/include/exec/system_scheduler.hpp
+++ b/include/exec/system_scheduler.hpp
@@ -284,13 +284,6 @@ struct __exec_system_bulk_sender_impl : public __exec_system_sender_interface {
 };
 
 
-// Phase 1 implementation, single implementation
-static __exec_system_context_impl* __get_exec_system_context_impl() {
-  static __exec_system_context_impl impl_;
-
-  return &impl_;
-}
-
 inline __exec_system_scheduler_interface* __exec_system_context_impl::get_scheduler() noexcept {
   // TODO: ref counting etc
   return new __exec_system_scheduler_impl(this, pool_.get_scheduler());
@@ -312,6 +305,17 @@ inline __exec_system_sender_interface* __exec_system_scheduler_impl::bulk(
 }
 
 
+
+// Phase 1 implementation, single implementation
+// TODO: Make a weak symbol and replace in a test
+static __exec_system_context_impl* __get_exec_system_context_impl() {
+  static __exec_system_context_impl impl_;
+
+  return &impl_;
+}
+
+// TODO: Move everything above here to a detail header and wrap in a
+// namespace to represent extern "C"
 
 
 namespace exec {

--- a/test/exec/test_system_scheduler.cpp
+++ b/test/exec/test_system_scheduler.cpp
@@ -93,3 +93,59 @@ TEST_CASE("simple chain task on system context", "[types][system_scheduler]") {
   (void) snd;
   (void) snd2;
 }
+
+TEST_CASE("simple bulk task on system context", "[types][system_scheduler]") {
+  std::thread::id this_id = std::this_thread::get_id();
+  constexpr size_t num_tasks = 2;
+  std::thread::id pool_ids[num_tasks];
+  exec::system_context ctx;
+  exec::system_scheduler sched = ctx.get_scheduler();
+
+  auto bulk_snd = ex::bulk(
+    ex::schedule(sched),
+    num_tasks,
+    [&](long id) {
+      pool_ids[id] = std::this_thread::get_id();
+    });
+
+  ex::sync_wait(std::move(bulk_snd));
+
+  for(size_t i = 0; i < num_tasks; ++i) {
+    REQUIRE(pool_ids[i] != std::thread::id{});
+    REQUIRE(this_id!=pool_ids[i]);
+  }
+  (void) bulk_snd;
+}
+
+
+TEST_CASE("simple bulk chaining on system context", "[types][system_scheduler]") {
+  std::thread::id this_id = std::this_thread::get_id();
+  constexpr size_t num_tasks = 2;
+  std::thread::id pool_id{};
+  std::thread::id pool_ids[num_tasks];
+  exec::system_context ctx;
+  exec::system_scheduler sched = ctx.get_scheduler();
+
+  auto snd = ex::then(ex::schedule(sched),
+    [&] {
+      pool_id = std::this_thread::get_id();
+    });
+
+  auto bulk_snd = ex::bulk(std::move(snd),
+    num_tasks,
+    [&](long id) {
+      pool_ids[id] = std::this_thread::get_id();
+    });
+
+  ex::sync_wait(std::move(bulk_snd));
+
+
+  REQUIRE(pool_id != std::thread::id{});
+  REQUIRE(this_id!=pool_id);
+  for(size_t i = 0; i < num_tasks; ++i) {
+    REQUIRE(pool_ids[i] != std::thread::id{});
+    REQUIRE(this_id!=pool_ids[i]);
+  }
+  (void) snd;
+  (void) bulk_snd;
+}

--- a/test/exec/test_system_scheduler.cpp
+++ b/test/exec/test_system_scheduler.cpp
@@ -105,7 +105,6 @@ TEST_CASE("simple bulk task on system context", "[types][system_scheduler]") {
     ex::schedule(sched),
     num_tasks,
     [&](long id) {
-      std::cerr << "Bulk call on id: " << id << "\n";
       pool_ids[id] = std::this_thread::get_id();
     });
 

--- a/test/exec/test_system_scheduler.cpp
+++ b/test/exec/test_system_scheduler.cpp
@@ -96,7 +96,7 @@ TEST_CASE("simple chain task on system context", "[types][system_scheduler]") {
 
 TEST_CASE("simple bulk task on system context", "[types][system_scheduler]") {
   std::thread::id this_id = std::this_thread::get_id();
-  constexpr size_t num_tasks = 2;
+  constexpr size_t num_tasks = 1;
   std::thread::id pool_ids[num_tasks];
   exec::system_context ctx;
   exec::system_scheduler sched = ctx.get_scheduler();
@@ -121,7 +121,7 @@ TEST_CASE("simple bulk task on system context", "[types][system_scheduler]") {
 
 TEST_CASE("simple bulk chaining on system context", "[types][system_scheduler]") {
   std::thread::id this_id = std::this_thread::get_id();
-  constexpr size_t num_tasks = 2;
+  constexpr size_t num_tasks = 1;
   std::thread::id pool_id{};
   std::thread::id propagated_pool_ids[num_tasks];
   std::thread::id pool_ids[num_tasks];

--- a/test/exec/test_system_scheduler.cpp
+++ b/test/exec/test_system_scheduler.cpp
@@ -105,7 +105,7 @@ TEST_CASE("simple bulk task on system context", "[types][system_scheduler]") {
     ex::schedule(sched),
     num_tasks,
     [&](long id) {
-      std::cerr << "Bull call on id: " << id << "\n";
+      std::cerr << "Bulk call on id: " << id << "\n";
       pool_ids[id] = std::this_thread::get_id();
     });
 

--- a/test/exec/test_system_scheduler.cpp
+++ b/test/exec/test_system_scheduler.cpp
@@ -96,7 +96,7 @@ TEST_CASE("simple chain task on system context", "[types][system_scheduler]") {
 
 TEST_CASE("simple bulk task on system context", "[types][system_scheduler]") {
   std::thread::id this_id = std::this_thread::get_id();
-  constexpr size_t num_tasks = 1;
+  constexpr size_t num_tasks = 16;
   std::thread::id pool_ids[num_tasks];
   exec::system_context ctx;
   exec::system_scheduler sched = ctx.get_scheduler();
@@ -121,7 +121,7 @@ TEST_CASE("simple bulk task on system context", "[types][system_scheduler]") {
 
 TEST_CASE("simple bulk chaining on system context", "[types][system_scheduler]") {
   std::thread::id this_id = std::this_thread::get_id();
-  constexpr size_t num_tasks = 1;
+  constexpr size_t num_tasks = 16;
   std::thread::id pool_id{};
   std::thread::id propagated_pool_ids[num_tasks];
   std::thread::id pool_ids[num_tasks];
@@ -148,7 +148,7 @@ TEST_CASE("simple bulk chaining on system context", "[types][system_scheduler]")
   REQUIRE(this_id!=pool_id);
   for(size_t i = 0; i < num_tasks; ++i) {
     REQUIRE(pool_ids[i] != std::thread::id{});
-    REQUIRE(propagated_pool_ids[i] == std::thread::id{});
+    REQUIRE(propagated_pool_ids[i] == pool_id);
     REQUIRE(this_id!=pool_ids[i]);
   }
   (void) snd;

--- a/test/exec/test_system_scheduler.cpp
+++ b/test/exec/test_system_scheduler.cpp
@@ -105,6 +105,7 @@ TEST_CASE("simple bulk task on system context", "[types][system_scheduler]") {
     ex::schedule(sched),
     num_tasks,
     [&](long id) {
+      std::cerr << "Bull call on id: " << id << "\n";
       pool_ids[id] = std::this_thread::get_id();
     });
 


### PR DESCRIPTION
Bulk algorithm abstracted through the low-level interfaces.

This version only supports direct bulk enqueue on the scheduler - so it uses the completion_scheduler but does not offer an opportunity to optimize for a prior system_context bulk algorithm.